### PR TITLE
Performance optimization: only perform sort once when adding multiple items via addAll

### DIFF
--- a/angular-collection.js
+++ b/angular-collection.js
@@ -65,10 +65,15 @@ angular.module('ngCollection', []).
       },
 
       addAll: function(objArr, options) {
+        options || (options = {});
+        var sort = this.comparator && options.sort !== false;
+
         for (var i = 0; i < objArr.length; i++) {
           var obj = objArr[i];
-          this.add(obj, options);
+          this.add(obj, angular.extend(options, { sort: false }));
         }
+
+        if (sort) this.sort();
 
         return this;
       },

--- a/test/collectionSpec.js
+++ b/test/collectionSpec.js
@@ -251,6 +251,13 @@ describe("collection", function() {
 
       expect(sortedTodos.last()).to.equal(c);
     });
+
+    it("should sort collection by given comparator after #addAll", function(){
+      var sortedTodos = $collection.getInstance({comparator: "label"});
+      sortedTodos.addAll([a, c, b]);
+
+      expect(sortedTodos.last()).to.equal(c);
+    });
   });
 
   describe("#remove", function(){


### PR DESCRIPTION
This can be a huge performance gain for large collections that use a comparator.
