### PR TITLE
fix(sort): do not require comparator to be a string

### DIFF
--- a/angular-collection.js
+++ b/angular-collection.js
@@ -42,7 +42,7 @@ angular.module('ngCollection', []).
       add: function(obj, options) {
         options || (options = {});
         var id, sort, existing;
-        sort = this.comparator && options.sort !== false;
+        sort = options.sort !== false;
 
         if (!obj[this.idAttribute]) {
           obj[this.idAttribute] = guid();
@@ -65,7 +65,7 @@ angular.module('ngCollection', []).
 
       addAll: function(objArr, options) {
         options || (options = {});
-        var sort = this.comparator && options.sort !== false;
+        var sort = options.sort !== false;
 
         for (var i = 0; i < objArr.length; i++) {
           var obj = objArr[i];


### PR DESCRIPTION
Given that angular's `orderBy` filter [supports a function or array as arguments](http://docs.angularjs.org/api/ng.filter:orderBy) (for example, if you want to sort first by one thing, then if equivalent by another) I don't see why we're requiring the comparator to be a string.  With this change you can do something like this:

```
new $collection({ comparator: ['-date', '+name] })
```

To sort first by date descending, then if equivalent by name ascending.
